### PR TITLE
applet: Make the AppletManager more resilient in the face of errors

### DIFF
--- a/g13gui/applet/switcher.py
+++ b/g13gui/applet/switcher.py
@@ -27,9 +27,7 @@ class Switcher(Observer):
         self._applets = []
 
         self._appletManager.registerObserver(self, {'activeApplet', 'applet'})
-        self.changeTrigger(self.onNewApplet,
-                           changeType=ChangeType.ADD,
-                           keys={'applet'})
+        self.changeTrigger(self.onAppletChange, keys={'applet'})
 
         self._initWidgets()
 
@@ -37,7 +35,7 @@ class Switcher(Observer):
     def bus_name(self):
         return self
 
-    def onNewApplet(self, subject, changeType, key, data):
+    def onAppletChange(self, subject, changeType, key, data):
         self._applets = sorted(self._appletManager.appletNames)
         self._lv.model = self._applets
         self._lv.update()


### PR DESCRIPTION
This wraps most of the proxy calls with some exception handling code which
removes an applet from the list of applets. This is kinda remedial, but should
make developing applets a bit smoother, as we end up restarting them
periodically. IOW, this prevents the configurator from completely crashing out.

  - Give switcher the ability to handle applet removals
  - Wrap most proxy methods in try...except blocks
  - Add a removeActiveApplet method to kill off the currently stuck applet in
    the face of an error.

Closes #7 