### PR TITLE
Fixes rpm build issues described in #33 and implements fedora-install.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ fedora-clean:
 	rm -rf ~/rpmbuild
 
 fedora-install:
+	yum install build/g13gui*.rpm
 
 debian:
 	mkdir -p build

--- a/g13gui.spec
+++ b/g13gui.spec
@@ -1,17 +1,18 @@
-Name:       g13gui
-Version:    0.1.0
-Release:    1
-Summary:    A user-space driver and GUI configurator for the Logitech G13
-License:    BSD
-URL:        https://github.com/jtgans/g13gui
-Requires:   python3-dbus
-Requires:   python3-appdirs
-Requires:   python3-evdev
-Requires:   python3-pillow
-Requires:   python3-gobject
-Requires:   python3-pyusb
-Requires:   gtk3
-Requires:   libappindicator-gtk3
+Name:          g13gui
+Version:       0.1.0
+Release:       1
+Summary:       A user-space driver and GUI configurator for the Logitech G13
+License:       BSD
+URL:           https://github.com/jtgans/g13gui
+Requires:      python3-dbus
+Requires:      python3-appdirs
+Requires:      python3-evdev
+Requires:      python3-pillow
+Requires:      python3-gobject
+Requires:      python3-pyusb
+Requires:      gtk3
+Requires:      libappindicator-gtk3
+Source:        g13gui-%{version}.tar.gz
 BuildRequires: meson
 
 %description
@@ -19,12 +20,11 @@ This is the companion application to the Logitech G13 gameboard, and provides
 both configuration tooling, applet hosting, and also a user space driver to
 handle translation of keypresses to real Linux input events by way of uinput.
 
-%meson
+# Need this definition, or else meson_install trips up trying to find debug info
+%define debug_package %{nil}
 
 %prep
-cd %{_topdir}/BUILD
-rm -rf *
-tar zxf %{_topdir}/SOURCES/g13gui-%{version}.tar.gz
+%autosetup -c
 
 %build
 %meson
@@ -34,12 +34,13 @@ tar zxf %{_topdir}/SOURCES/g13gui-%{version}.tar.gz
 %meson_install
 
 %check
+%meson_test
 
 %files
 /usr/bin/g13-clock
 /usr/bin/g13-profiles
 /usr/bin/g13gui
-/usr/lib/python3.12/site-packages/g13gui/*
+/usr/lib/python3.*/site-packages/g13gui/*
 /usr/lib/udev/rules.d/91-g13.rules
 /usr/share/applications/com.theonelab.g13.*.desktop
 /usr/share/icons/hicolor/*


### PR DESCRIPTION
* Adds in a Source definition to allow the `%prep` macro to use `%autosetup`
* Adds `%meson_test` to the `%check` macro to follow usual standards
* Updated `%files` macro to use a glob for the versioned python file to allow it to work for any python 3 version
* Implements `fedora-install` in the `Makefile` using `yum`